### PR TITLE
prevent page breaks in awkward locations

### DIFF
--- a/src/ResumeBuilder/Themes/JoeTheme/Components.hs
+++ b/src/ResumeBuilder/Themes/JoeTheme/Components.hs
@@ -59,6 +59,31 @@ jLink color fontSize url = (a ! applyStyles css ! (A.href . fromString) url) . t
         ("font-size", fontSize)
       ]
 
+-- For a prettier output when printing to pdf, prevent the body from being
+-- broken in two by a page break.
+--
+-- Debugging tip: add "border: 1px solid black;" to visualize the sections and
+-- make sure they are indeed small enough that you wouldn't mind wasting that
+-- amount of space in order to bump it to the next page.
+jShortSection :: Html -> Html
+jShortSection = H.div ! A.style "break-inside: avoid;"
+
+-- Similar to @map jShortSection@, but also prevents a page break between the
+-- header and the first item.
+jHeaderAndShortSections :: Html -> [Html] -> Html
+jHeaderAndShortSections header (firstItem:items) = do
+  jShortSection $ do
+    header
+    firstItem
+  forM_ items $ \item -> do
+    jShortSection $ do
+      item
+jTitleAndShortSections header items = do
+  jShortSection $ do
+    header
+    sequence_ items
+
+
 jListItem :: ToMarkup a => String -> String -> a -> Html
 jListItem color fontSize = (li ! applyStyles css) . toHtml
   where

--- a/src/ResumeBuilder/Themes/JoeTheme/Template.hs
+++ b/src/ResumeBuilder/Themes/JoeTheme/Template.hs
@@ -27,6 +27,12 @@ renderResume config = docTypeHtml $ do
           (fontSize2 theme')
           (sectionTitleBorderEnabled theme')
           headerText
+      renderShortSection headerText body = do
+        jShortSection $ do
+          renderSectionHeader headerText
+          body
+      renderLongSection headerText = do
+        jHeaderAndShortSections (renderSectionHeader headerText)
 
       renderPersonNameHeader headerText =
         jHeader1
@@ -89,40 +95,33 @@ renderResume config = docTypeHtml $ do
                 )
 
       -- Short introduction section
-      H.div $ do
-        renderSectionHeader . shortIntroTitle $ documentTitles'
+      renderShortSection (shortIntroTitle documentTitles') $ do
         forM_ (shortIntro personal') (jJustified bodyColor' (fontSize3 theme'))
 
       -- Work experience section
-      H.div $ do
-        renderSectionHeader . workExperienceTitle $ documentTitles'
-        forM_ (experience config) (jExperienceItem theme')
+      renderLongSection (workExperienceTitle documentTitles')
+        (fmap (jExperienceItem theme') (experience config))
 
       br
 
       -- Education section
-      H.div $ do
-        renderSectionHeader . educationTitle $ documentTitles'
-        forM_ (education config) (jExperienceItem theme')
+      renderLongSection (educationTitle documentTitles')
+        (fmap (jExperienceItem theme') (education config))
 
       -- Languages section
-      H.div $ do
-        renderSectionHeader . languagesTitle $ documentTitles'
+      renderShortSection (languagesTitle documentTitles') $ do
         jLanguageSection $ languages config
 
       -- Driver license section
-      H.div $ do
-        renderSectionHeader . driverLicenseTitle $ documentTitles'
+      renderShortSection (driverLicenseTitle documentTitles') $ do
         ul $ forM_ (driverLicense config) (jListItem bodyColor' (fontSize3 theme'))
 
       -- Interests hobbies section
-      H.div $ do
-        renderSectionHeader . interestsHobbiesTitle $ documentTitles'
-        forM_ (interestsHobbies config) (jJustified bodyColor' (fontSize3 theme'))
+      renderLongSection (interestsHobbiesTitle documentTitles')
+        (fmap (jJustified bodyColor' (fontSize3 theme')) (interestsHobbies config))
 
       -- Websites section
-      H.div $ do
-        renderSectionHeader . seeMyWebsitesTitle $ documentTitles'
+      renderShortSection (seeMyWebsitesTitle documentTitles') $ do
         jFlexContainer' $ do
           forM_
             (blogs . websites . contact $ personal')
@@ -152,10 +151,11 @@ renderResume config = docTypeHtml $ do
             )
 
       -- Credits to hsResumeBuilder
-      H.div ! applyStyles [("margin-top", "16px"), ("text-align", "center")] $ do
-        small $ do
-          jLink
-            linkColor'
-            fontSize3'
-            "https://github.com/averageflow/hsresumebuilder"
-            "λ This document has been proudly auto-generated with Haskell code"
+      jShortSection $ do
+        H.div ! applyStyles [("margin-top", "16px"), ("text-align", "center")] $ do
+          small $ do
+            jLink
+              linkColor'
+              fontSize3'
+              "https://github.com/averageflow/hsresumebuilder"
+              "λ This document has been proudly auto-generated with Haskell code"


### PR DESCRIPTION
If I follow the instructions in the README and print-to-pdf, the page breaks can happen in very unfortunate positions, such as in the middle of a piece of text:

![page-break-mid-text](https://user-images.githubusercontent.com/49000/175131320-1e7b17cc-7051-4433-9864-d0fbbab07c88.png)

Just after a header:

![page-break-after-header](https://user-images.githubusercontent.com/49000/175131427-23b5d484-8a4e-4a09-a2ab-26c9cebf4277.png)

Or (less annoyingly) in the middle of a sub-section describing a position:

![page-break-mid-sub-section](https://user-images.githubusercontent.com/49000/175131486-91a11ca8-39f3-43c2-a0aa-21ededa0ccc0.png)

This PR forces page breaks to appear between sections or sub-sections, resulting in a much more pleasing on-the-page output.

---

The API for long sections is slightly unfortunate: the body must be given as a list instead of a do block containing a for loop, so that we can treat the first item specially. Alas, attaching to the header the CSS "break-after: avoid;" doesn't seem to work, so we instead have to use a "break-inside: avoid;" region which includes both the title and the first element.